### PR TITLE
Fixed the window closing issue on MacOS

### DIFF
--- a/fenster.h
+++ b/fenster.h
@@ -141,10 +141,10 @@ FENSTER_API int fenster_loop(struct fenster *f) {
   switch (evtype) {
   case 1: /* NSEventTypeMouseDown */
     f->mouse |= 1;
-    return 0;
+    break;
   case 2: /* NSEventTypeMouseUp*/
     f->mouse &= ~1;
-    return 0;
+    break;
   case 5:
   case 6: { /* NSEventTypeMouseMoved */
     CGPoint xy = msg(CGPoint, ev, "locationInWindow");


### PR DESCRIPTION
The primary event loop switch statement was setting the fenster struct mouse element to indicate a mouse event had occurred and was then returning zero. Instead it should break and pass those events onto Cocoa so that the delegate can get triggered.