### PR TITLE
Fixes for WIN32 target.

### DIFF
--- a/fenster.h
+++ b/fenster.h
@@ -206,7 +206,8 @@ static LRESULT CALLBACK fenster_wndproc(HWND hwnd, UINT msg, WPARAM wParam,
             .bmiHeader.biHeight = -f->height
         };
   	f->scale = MIN((float)f->display_width/f->width, (float)f->display_height/f->height);
-		f->scale = (int)f->scale;
+//	if you want integer scaling 
+//		f->scale = (int)f->scale;
 		int draw_width = f->width*f->scale;
 		int draw_height = f->height*f->scale;
 		f->xorigin=(f->display_width-draw_width)/2;


### PR DESCRIPTION
correctly clears area outside of display.
letterboxes results.
mouse coords reflect window scale. i.e. coords are within the framebuffer bounds.
audio plays now.
window is correct size at startup
window can no longer minimize below intended framebuffer size