### PR TITLE
[examples/minimal-zig] Fix breaking changes of zig nightly / v0.11

### DIFF
--- a/examples/minimal-zig/build.zig
+++ b/examples/minimal-zig/build.zig
@@ -9,11 +9,17 @@ pub fn build(b: *std.build.Builder) void {
 
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+    const optimize = b.standardOptimizeOption(.{});
 
-    const exe = b.addExecutable("minimal-zig", "src/main.zig");
-    exe.setTarget(target);
-    exe.setBuildMode(mode);
+    // const exe = b.addExecutable("minimal-zig", "src/main.zig");
+
+    const exe = b.addExecutable(.{
+        .name = "minimal-zig",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
     exe.addIncludePath("src");
     exe.addCSourceFile("src/fenster.c", &[_][]const u8{});
     if (exe.target.isDarwin()) {
@@ -24,21 +30,48 @@ pub fn build(b: *std.build.Builder) void {
         exe.linkSystemLibrary("X11");
     }
     exe.linkSystemLibrary("c");
-    exe.install();
 
-    const run_cmd = exe.run();
+    // This declares intent for the executable to be installed into the
+    // standard location when the user invokes the "install" step (the default
+    // step when running `zig build`).
+    b.installArtifact(exe);
+
+    // This *creates* a Run step in the build graph, to be executed when another
+    // step is evaluated that depends on it. The next line below will establish
+    // such a dependency.
+    const run_cmd = b.addRunArtifact(exe);
+
+    // By making the run step depend on the install step, it will be run from the
+    // installation directory rather than directly from within the cache directory.
+    // This is not necessary, however, if the application depends on other installed
+    // files, this ensures they will be present and in the expected location.
     run_cmd.step.dependOn(b.getInstallStep());
+
+    // This allows the user to pass arguments to the application in the build
+    // command itself, like this: `zig build run -- arg1 arg2 etc`
     if (b.args) |args| {
         run_cmd.addArgs(args);
     }
 
+    // This creates a build step. It will be visible in the `zig build --help` menu,
+    // and can be selected like this: `zig build run`
+    // This will evaluate the `run` step rather than the default, which is "install".
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    const exe_tests = b.addTest("src/main.zig");
-    exe_tests.setTarget(target);
-    exe_tests.setBuildMode(mode);
+    // Creates a step for unit testing. This only builds the test executable
+    // but does not run it.
+    const unit_tests = b.addTest(.{
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
     const test_step = b.step("test", "Run unit tests");
-    test_step.dependOn(&exe_tests.step);
+    test_step.dependOn(&run_unit_tests.step);
 }

--- a/examples/minimal-zig/src/fenster.zig
+++ b/examples/minimal-zig/src/fenster.zig
@@ -7,7 +7,7 @@ pub const Fenster = struct {
 };
 
 pub fn new(comptime w: i32, comptime h: i32, title: [:0]const u8) type {
-    var buf: [w*h]u32 = undefined;
+    var buf: [w * h]u32 = undefined;
     const f = .{
         .width = w,
         .height = h,

--- a/examples/minimal-zig/src/main.zig
+++ b/examples/minimal-zig/src/main.zig
@@ -21,8 +21,8 @@ pub fn main() void {
             break;
         }
         // Render x^y^t pattern
-        for (buf) |_, i| {
-            buf[i] = @intCast(u32, i % 320) ^ @intCast(u32, i / 240) ^ t;
+        for (buf, 0..) |_, i| {
+            buf[i] = @as(u32, @intCast(i % 320)) ^ @as(u32, @intCast(i / 240)) ^ t;
         }
         t +%= 1;
         // Keep ~60 FPS


### PR DESCRIPTION
The latest nightly of zig has some breaking changes to the `std.build` API 

Summary of changes
- Release options have been renamed to optimization
- Creating tests, libraries, and executables now takes a struct with options as the parameter instead of using a setter API
- Ran `zig fmt`

https://devlog.hexops.com/2023/zig-0-11-breaking-build-changes/