### PR TITLE
Update Makefile to compile sound example correctly on windows

### DIFF
--- a/examples/sound-c/Makefile
+++ b/examples/sound-c/Makefile
@@ -1,7 +1,7 @@
 CFLAGS ?= -Wall -Wextra -std=c99
 
 ifeq ($(OS),Windows_NT)
-	LDFLAGS = -lgdi32
+	LDFLAGS = -lgdi32 -lwinmm
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)


### PR DESCRIPTION
With this change it compiles on MINGW64 URT (but it doesn't produce any sound on my machine).