### PR TITLE
add required package description

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Compile it and run:
 
 ```
 # Linux
+# libasound2-dev package required in Debian/Ubuntu.
 cc main.c -lX11 -lasound -o main && ./main
 # macOS
 cc main.c -framework Cocoa -framework AudioToolbox -o main && ./main


### PR DESCRIPTION
Debian/Ubuntu requires the libasound2-dev package, so I thought it would be easier to use if it was described in the README.

Thanks in advance.