### PR TITLE
Added emscripten support

### DIFF
--- a/examples/doom-c/Makefile.fenster
+++ b/examples/doom-c/Makefile.fenster
@@ -1,18 +1,28 @@
 CFLAGS+=-Wall -DNORMALUNIX -DLINUX -DSNDSERV -D_DEFAULT_SOURCE
-LIBS+=-lm -lc
-ifeq ($(OS),Windows_NT)
-	LIBS+= -lgdi32
+LIBS+=-lm 
+
+ifdef EMSDK
+	CC = emcc
+	LDFLAGS += -s ASYNCIFY -s WASM=0
+	WEB_DIR = web
+	WEB = $(WEB_DIR)/index.html
+	OUTPUT = $(WEB)
+	PORT ?= 9000
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S),Darwin)
-		LIBS+=-framework Cocoa
+	ifeq ($(OS),Windows_NT)
+		LIBS+= -lgdi32
 	else
-		LIBS+=-lX11
+		UNAME_S := $(shell uname -s)
+		ifeq ($(UNAME_S),Darwin)
+			LIBS+=-framework Cocoa
+		else
+			LIBS+=-lX11
+		endif
 	endif
+	OUTPUT=doomgeneric
 endif
 
 OBJDIR=build
-OUTPUT=doomgeneric
 
 SRC_DOOM = i_main.o dummy.o am_map.o doomdef.o doomstat.o dstrings.o d_event.o d_items.o d_iwad.o d_loop.o d_main.o d_mode.o d_net.o f_finale.o f_wipe.o g_game.o hu_lib.o hu_stuff.o info.o i_cdmus.o i_endoom.o i_joystick.o i_scale.o i_sound.o i_system.o i_timer.o memio.o m_argv.o m_bbox.o m_cheat.o m_config.o m_controls.o m_fixed.o m_menu.o m_misc.o m_random.o p_ceilng.o p_doors.o p_enemy.o p_floor.o p_inter.o p_lights.o p_map.o p_maputl.o p_mobj.o p_plats.o p_pspr.o p_saveg.o p_setup.o p_sight.o p_spec.o p_switch.o p_telept.o p_tick.o p_user.o r_bsp.o r_data.o r_draw.o r_main.o r_plane.o r_segs.o r_sky.o r_things.o sha1.o sounds.o statdump.o st_lib.o st_stuff.o s_sound.o tables.o v_video.o wi_stuff.o w_checksum.o w_file.o w_main.o w_wad.o z_zone.o w_file_stdc.o i_input.o i_video.o doomgeneric.o doomgeneric_fenster.o
 OBJS += $(addprefix $(OBJDIR)/, $(SRC_DOOM))
@@ -23,8 +33,17 @@ clean:
 	rm -rf $(OBJDIR)
 	rm -f $(OUTPUT)
 
+ifdef EMSDK
+$(OUTPUT): $(OBJS) | $(WEB_DIR)
+	@echo Creating $@...
+	$(CC) $^ -o $@ $(LDFLAGS) --preload-file doom2.wad
+
+$(WEB_DIR):
+	mkdir -p $(WEB_DIR)
+else
 $(OUTPUT):	$(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) -o $(OUTPUT) $(LIBS)
+endif
 
 $(OBJS): | $(OBJDIR)
 
@@ -37,3 +56,6 @@ $(OBJDIR)/%.o:	%.c
 x:
 	@echo $(SRC_DOOM)
 
+serve: $(WEB)
+	@echo Running server on port $(PORT)
+	@-cd $(WEB_DIR) && python3 -m http.server $(PORT)

--- a/examples/doom-c/doomgeneric_fenster.c
+++ b/examples/doom-c/doomgeneric_fenster.c
@@ -1,3 +1,5 @@
+#include <ctype.h>
+
 #include "../../fenster.h"
 #include "doomgeneric.h"
 #include "doomkeys.h"

--- a/examples/drawing-c/Makefile
+++ b/examples/drawing-c/Makefile
@@ -1,15 +1,36 @@
 CFLAGS ?= -Wall -Wextra -std=c99
 
-ifeq ($(OS),Windows_NT)
-	LDFLAGS = -lgdi32
+ifdef EMSDK
+	CC = emcc
+	LDFLAGS += -s ASYNCIFY -s ASYNCIFY_IGNORE_INDIRECT
+	WEB_DIR = web
+	WEB = $(WEB_DIR)/index.html
+	OUTPUT = $(WEB)
+	PORT ?= 9000
 else
-	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S),Darwin)
-		LDFLAGS = -framework Cocoa
+	ifeq ($(OS),Windows_NT)
+		LDFLAGS = -lgdi32
 	else
-		LDFLAGS = -lX11
+		UNAME_S := $(shell uname -s)
+		ifeq ($(UNAME_S),Darwin)
+			LDFLAGS = -framework Cocoa
+		else
+			LDFLAGS = -lX11
+		endif
 	endif
 endif
 
+ifdef EMSDK
+$(OUTPUT): main.c ../../fenster.h | $(WEB_DIR)
+	$(CC) main.c -I../.. -o $@ $(CFLAGS) $(LDFLAGS)
+
+$(WEB_DIR):
+	mkdir -p $(WEB_DIR)
+else
 main: main.c ../../fenster.h
 	$(CC) main.c -I../.. -o $@ $(CFLAGS) $(LDFLAGS)
+endif
+
+serve: $(WEB)
+	@echo Running server on port $(PORT)
+	@-cd $(WEB_DIR) && python3 -m http.server $(PORT)

--- a/examples/sound-c/Makefile
+++ b/examples/sound-c/Makefile
@@ -1,7 +1,7 @@
 CFLAGS ?= -Wall -Wextra -std=c99
 
 ifeq ($(OS),Windows_NT)
-	LDFLAGS = -lgdi32
+	LDFLAGS = -lgdi32 -lwinmm
 else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)

--- a/fenster_audio.h
+++ b/fenster_audio.h
@@ -95,10 +95,10 @@ FENSTER_API void fenster_audio_write(struct fenster_audio *fa, float *buf,
 }
 #elif defined(_WIN32)
 FENSTER_API int fenster_audio_open(struct fenster_audio *fa) {
-  WAVEFORMATEX wfx = {WAVE_FORMAT_PCM, 1, FENSTER_SAMPLE_RATE, FENSTER_SAMPLE_RATE * 2, 1, 16, 0};
+  WAVEFORMATEX wfx = {WAVE_FORMAT_PCM, 1, FENSTER_SAMPLE_RATE, FENSTER_SAMPLE_RATE * 2, 2, 16, 0};
   waveOutOpen(&fa->wo, WAVE_MAPPER, &wfx, 0, 0, CALLBACK_NULL);
   for (int i = 0; i < 2; i++) {
-    fa->hdr[i].lpData = fa->buf[i];
+    fa->hdr[i].lpData = (LPSTR)fa->buf[i];
     fa->hdr[i].dwBufferLength = FENSTER_AUDIO_BUFSZ * 2;
     waveOutPrepareHeader(fa->wo, &fa->hdr[i], sizeof(WAVEHDR));
     waveOutWrite(fa->wo, &fa->hdr[i], sizeof(WAVEHDR));


### PR DESCRIPTION
Hi, thank you for fenster. It is really nice to just drop the file into a directory and have a demo ready to go.

I spent some time adding support for emscripten in my fork because I wanted my demo to be runnable in a web browser as well.

I've modified the makefile in the drawing-c example to demonstrate how to build it once your emscripten environment is set up. It will create an output directory `web/` that contains all the HTML, JavaScript and wasm files. There is also a `serve` target in the Makefile that will use Python3's http module to serve the application on http://localhost:9000/ for testing purposes .