### PR TITLE
Emscripten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 main
+main.exe
+main.wasm
+main.js
+main.html
 a.out
 *.o
 *.elf

--- a/examples/drawing-c/Makefile
+++ b/examples/drawing-c/Makefile
@@ -1,15 +1,25 @@
-CFLAGS ?= -Wall -Wextra -std=c99
+CFLAGS ?= -I../.. -Wall -Wextra -std=c99
+
+# debug
+# CFLAGS += -g
 
 ifeq ($(OS),Windows_NT)
 	LDFLAGS = -lgdi32
+	TARGET_EXT = .exe
 else
 	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S),Darwin)
+	ifneq (,$(findstring emcc,$(CC)))
+		LDFLAGS = -lm -sASYNCIFY=1 -sSTACK_SIZE=524288
+		TARGET_EXT = .html
+	else ifeq ($(UNAME_S),Darwin)
 		LDFLAGS = -framework Cocoa
 	else
-		LDFLAGS = -lX11
+		LDFLAGS = -lX11 -lasound -lm
+		TARGET_EXT =
 	endif
 endif
 
-main: main.c ../../fenster.h
-	$(CC) main.c -I../.. -o $@ $(CFLAGS) $(LDFLAGS)
+TARGET = main$(TARGET_EXT)
+
+$(TARGET): main.c
+	$(CC) $? -o $(TARGET) $(CFLAGS) $(LDFLAGS)

--- a/examples/drawing-c/main.c
+++ b/examples/drawing-c/main.c
@@ -1,4 +1,8 @@
+#ifdef EMSCRIPTEN
+#include "fenster-emscripten.h"
+#else
 #include "fenster.h"
+#endif
 
 #define W 320
 #define H 240

--- a/examples/input-c/Makefile
+++ b/examples/input-c/Makefile
@@ -1,15 +1,25 @@
-CFLAGS ?= -Wall -Wextra -std=c99
+CFLAGS ?= -I../.. -Wall -Wextra -std=c99
+
+# debug
+# CFLAGS += -g
 
 ifeq ($(OS),Windows_NT)
 	LDFLAGS = -lgdi32
+	TARGET_EXT = .exe
 else
 	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S),Darwin)
+	ifneq (,$(findstring emcc,$(CC)))
+		LDFLAGS = -lm -sASYNCIFY=1 -sSTACK_SIZE=524288
+		TARGET_EXT = .html
+	else ifeq ($(UNAME_S),Darwin)
 		LDFLAGS = -framework Cocoa
 	else
-		LDFLAGS = -lX11
+		LDFLAGS = -lX11 -lasound -lm
+		TARGET_EXT =
 	endif
 endif
 
-main: main.c ../../fenster.h
-	$(CC) main.c -I../.. -o $@ $(CFLAGS) $(LDFLAGS)
+TARGET = main$(TARGET_EXT)
+
+$(TARGET): main.c
+	$(CC) $? -o $(TARGET) $(CFLAGS) $(LDFLAGS)

--- a/examples/input-c/main.c
+++ b/examples/input-c/main.c
@@ -1,4 +1,8 @@
+#ifdef EMSCRIPTEN
+#include "fenster-emscripten.h"
+#else
 #include "fenster.h"
+#endif
 
 #define W 320
 #define H 240

--- a/examples/minimal-c/Makefile
+++ b/examples/minimal-c/Makefile
@@ -12,7 +12,7 @@ else
 		LDFLAGS = -lm -sASYNCIFY=1 -sSTACK_SIZE=524288
 		TARGET_EXT = .html
 	else ifeq ($(UNAME_S),Darwin)
-		LDFLAGS = -framework Cocoa -framework AudioToolbox
+		LDFLAGS = -framework Cocoa
 	else
 		LDFLAGS = -lX11 -lasound -lm
 		TARGET_EXT =

--- a/examples/minimal-c/Makefile
+++ b/examples/minimal-c/Makefile
@@ -1,15 +1,25 @@
-CFLAGS ?= -Wall -Wextra -std=c99
+CFLAGS ?= -I../.. -Wall -Wextra -std=c99
+
+# debug
+# CFLAGS += -g
 
 ifeq ($(OS),Windows_NT)
 	LDFLAGS = -lgdi32
+	TARGET_EXT = .exe
 else
 	UNAME_S := $(shell uname -s)
-	ifeq ($(UNAME_S),Darwin)
-		LDFLAGS = -framework Cocoa
+	ifneq (,$(findstring emcc,$(CC)))
+		LDFLAGS = -lm -sASYNCIFY=1 -sSTACK_SIZE=524288
+		TARGET_EXT = .html
+	else ifeq ($(UNAME_S),Darwin)
+		LDFLAGS = -framework Cocoa -framework AudioToolbox
 	else
-		LDFLAGS = -lX11
+		LDFLAGS = -lX11 -lasound -lm
+		TARGET_EXT =
 	endif
 endif
 
-main: main.c ../../fenster.h
-	$(CC) main.c -I../.. -o $@ $(CFLAGS) $(LDFLAGS)
+TARGET = main$(TARGET_EXT)
+
+$(TARGET): main.c
+	$(CC) $? -o $(TARGET) $(CFLAGS) $(LDFLAGS)

--- a/examples/minimal-c/main.c
+++ b/examples/minimal-c/main.c
@@ -1,4 +1,8 @@
+#ifdef EMSCRIPTEN
+#include "fenster-emscripten.h"
+#else
 #include "fenster.h"
+#endif
 
 #define W 320
 #define H 240

--- a/fenster-emscripten.h
+++ b/fenster-emscripten.h
@@ -1,0 +1,95 @@
+// this is an emscripten-only implementation of fenster
+
+#include <stdint.h>
+#include <stdlib.h>
+#include "emscripten.h"
+
+struct fenster {
+  const int width;
+  const int height;
+  uint32_t *buf;
+  uint8_t keys[256]; /* keys are mostly ASCII, but arrows are 17..20 */
+  int mod;       /* mod is 4 bits mask, ctrl=1, shift=2, alt=4, meta=8 */
+  int x;
+  int y;
+  int mouse;
+  const char *title; // I put it at the end, so everything else is fixed-length
+};
+
+// gives mem out-of-bounds error in emscripten, for some reason
+#define fenster_pixel(f, x, y) ((f)->buf[((y) * (f)->width) + (x)])
+
+static bool running = true;
+
+EM_JS(int, fenster_open, (struct fenster *f), {
+  if (!Module.canvas) {
+    Module.canvas = document.getElementById('canvas');
+    if (!Module.canvas) {
+      document.createElement("canvas");
+      document.appendElement(Module.canvas);
+    }
+  }
+  const width = Module.HEAP32[f/4];
+  const height = Module.HEAP32[(f/4) + 1];
+  Module.canvas.width = width;
+  Module.canvas.height = height;
+  Module.ctx = canvas.getContext("2d");
+  Module.screen = Module.ctx.getImageData(0, 0, width, height);
+
+  // TODO: handle mod
+
+  Module.canvas.addEventListener('mousemove', e => {
+    Module.HEAP32[(f/4) + 5] = e.offsetX;
+    Module.HEAP32[(f/4) + 6] = e.offsetX;
+  });
+
+  Module.canvas.addEventListener('mousedown', e => {
+    Module.HEAP32[(f/4) + 7] = e.which;
+  });
+
+  Module.canvas.addEventListener('mouseup', e => {
+    Module.HEAP32[(f/4) + 7] = 0;
+  });
+
+  Module.canvas.addEventListener('keydown', e => {
+    Module.HEAP32[ Module.HEAP32[(f/4) + 3] + e.keyCode] = 1;
+  });
+
+  Module.canvas.addEventListener('keyup', e => {
+    Module.HEAP32[ Module.HEAP32[(f/4) + 3] + e.keyCode] = 0;
+  });
+});
+
+EM_JS(void, emscripten_fenster_loop, (struct fenster *f), {
+  // set alpha to 100%
+  const pmax = f + 8 + Module.canvas.width * Module.canvas.height * 4;
+  for (let p=f+8;p < pmax;p+=4) {
+    Module.HEAPU8[p+3] = 0xFF;
+  }
+  const bufSize = Module.canvas.width*Module.canvas.height*4;
+  Module.screen.data.set(Module.HEAPU8.slice(f+8, f+8+bufSize));
+  Module.ctx.putImageData(Module.screen, 0, 0);
+});
+
+int fenster_loop(struct fenster *f) {
+  if (running) {
+    emscripten_fenster_loop(f);
+  }
+
+  // this is hack to make it not pin the main-loop (~60fps)
+  emscripten_sleep(16);
+
+  return running ? 0 : 1;
+}
+
+void fenster_close(struct fenster *f) {
+  running = false;
+}
+
+void fenster_sleep(int64_t ms) {
+  emscripten_sleep(ms);
+}
+
+EM_JS(int64_t, fenster_time, (void), {
+  return (new Date()).time;
+});

--- a/fenster-emscripten.h
+++ b/fenster-emscripten.h
@@ -31,6 +31,7 @@ EM_JS(int, fenster_open, (struct fenster *f), {
       document.appendElement(Module.canvas);
     }
   }
+  // the HEAP32 offset of fenster object
   const p32 = f/4;
   const width = Module.HEAP32[p32 + 1];
   const height = Module.HEAP32[p32 + 2];
@@ -38,8 +39,6 @@ EM_JS(int, fenster_open, (struct fenster *f), {
   Module.canvas.height = height;
   Module.ctx = canvas.getContext("2d");
   Module.screen = Module.ctx.getImageData(0, 0, width, height);
-
-  // TODO: handle mod
 
   Module.canvas.addEventListener('mousemove', e => {
     Module.HEAP32[p32 + 261] = e.offsetX;
@@ -56,16 +55,47 @@ EM_JS(int, fenster_open, (struct fenster *f), {
 
   Module.canvas.addEventListener('keydown', e => {
     Module.HEAP32[p32 + 4 + e.keyCode] = 1;
+
+    let mod = 0;
+    if (e.ctrlKey) {
+      mod+=1
+    }
+    if (e.shiftKey) {
+      mod+=2
+    }
+    if (e.altKey) {
+      mod+=4
+    }
+    if (e.metaKey) {
+      mod+=8
+    }
+    Module.HEAP32[p32 + 260] = mod;
   });
 
   Module.canvas.addEventListener('keyup', e => {
     Module.HEAP32[p32 + 4 + e.keyCode] = 0;
+
+    // TODO: not sure if I need to do this twice
+    let mod = 0;
+    if (e.ctrlKey) {
+      mod+=1
+    }
+    if (e.shiftKey) {
+      mod+=2
+    }
+    if (e.altKey) {
+      mod+=4
+    }
+    if (e.metaKey) {
+      mod+=8
+    }
+    Module.HEAP32[p32 + 260] = mod;
   });
 });
 
 EM_JS(void, emscripten_fenster_loop, (int width, int height, uint32_t* buf), {
   const byteSize = width * height * 4;
-  const buffer = Module.HEAPU8.subarray(buf, buf + byteSize);
+  const buffer = Module.HEAPU8.slice(buf, buf + byteSize);
   // set alpha to 100% and re-arrange RGBA
   let r,g,b = 0;
   for (let i=0;i<byteSize;i+=4) {

--- a/fenster-emscripten.h
+++ b/fenster-emscripten.h
@@ -12,10 +12,10 @@ struct fenster {      // byte   32bit
   const int height;   // 8      2
   uint32_t *buf;      // 12     3
   int keys[256];      // 16     4
-  int mod;            // 1040   257
-  int x;              // 1044   258
-  int y;              // 1048   259
-  int mouse;          // 1052   260
+  int mod;            // 1040   260
+  int x;              // 1044   261
+  int y;              // 1048   262
+  int mouse;          // 1052   263
 };
 
 #define fenster_pixel(f, x, y) ((f)->buf[((y) * (f)->width) + (x)])
@@ -42,16 +42,16 @@ EM_JS(int, fenster_open, (struct fenster *f), {
   // TODO: handle mod
 
   Module.canvas.addEventListener('mousemove', e => {
-    Module.HEAP32[p32 + 258] = e.offsetX;
-    Module.HEAP32[p32 + 259] = e.offsetY;
+    Module.HEAP32[p32 + 261] = e.offsetX;
+    Module.HEAP32[p32 + 262] = e.offsetY;
   });
 
   Module.canvas.addEventListener('mousedown', e => {
-    Module.HEAP32[p32 + 260] = e.which;
+    Module.HEAP32[p32 + 263] = e.which;
   });
 
   Module.canvas.addEventListener('mouseup', e => {
-    Module.HEAP32[p32 + 260] = 0;
+    Module.HEAP32[p32 + 263] = 0;
   });
 
   Module.canvas.addEventListener('keydown', e => {

--- a/fenster-emscripten.h
+++ b/fenster-emscripten.h
@@ -1,23 +1,25 @@
 // this is an emscripten-only implementation of fenster
+// make sure to add -sASYNCIFY
 
 #include <stdint.h>
 #include <stdlib.h>
 #include "emscripten.h"
 
-struct fenster {
-  const int width;
-  const int height;
-  uint32_t *buf;
-  uint8_t keys[256]; /* keys are mostly ASCII, but arrows are 17..20 */
-  int mod;       /* mod is 4 bits mask, ctrl=1, shift=2, alt=4, meta=8 */
-  int x;
-  int y;
-  int mouse;
-  const char *title; // I put it at the end, so everything else is fixed-length
+//                        offsets
+struct fenster {      // byte   32bit
+  const char *title;  // 0      0
+  const int width;    // 4      1
+  const int height;   // 8      2
+  uint32_t *buf;      // 12     3
+  int keys[256];      // 16     4
+  int mod;            // 1040   257
+  int x;              // 1044   258
+  int y;              // 1048   259
+  int mouse;          // 1052   260
 };
 
-// gives mem out-of-bounds error in emscripten, for some reason
 #define fenster_pixel(f, x, y) ((f)->buf[((y) * (f)->width) + (x)])
+#define fenster_sleep emscripten_sleep
 
 static bool running = true;
 
@@ -29,8 +31,9 @@ EM_JS(int, fenster_open, (struct fenster *f), {
       document.appendElement(Module.canvas);
     }
   }
-  const width = Module.HEAP32[f/4];
-  const height = Module.HEAP32[(f/4) + 1];
+  const p32 = f/4;
+  const width = Module.HEAP32[p32 + 1];
+  const height = Module.HEAP32[p32 + 2];
   Module.canvas.width = width;
   Module.canvas.height = height;
   Module.ctx = canvas.getContext("2d");
@@ -39,44 +42,53 @@ EM_JS(int, fenster_open, (struct fenster *f), {
   // TODO: handle mod
 
   Module.canvas.addEventListener('mousemove', e => {
-    Module.HEAP32[(f/4) + 5] = e.offsetX;
-    Module.HEAP32[(f/4) + 6] = e.offsetX;
+    Module.HEAP32[p32 + 258] = e.offsetX;
+    Module.HEAP32[p32 + 259] = e.offsetY;
   });
 
   Module.canvas.addEventListener('mousedown', e => {
-    Module.HEAP32[(f/4) + 7] = e.which;
+    Module.HEAP32[p32 + 260] = e.which;
   });
 
   Module.canvas.addEventListener('mouseup', e => {
-    Module.HEAP32[(f/4) + 7] = 0;
+    Module.HEAP32[p32 + 260] = 0;
   });
 
   Module.canvas.addEventListener('keydown', e => {
-    Module.HEAP32[ Module.HEAP32[(f/4) + 3] + e.keyCode] = 1;
+    Module.HEAP32[p32 + 4 + e.keyCode] = 1;
   });
 
   Module.canvas.addEventListener('keyup', e => {
-    Module.HEAP32[ Module.HEAP32[(f/4) + 3] + e.keyCode] = 0;
+    Module.HEAP32[p32 + 4 + e.keyCode] = 0;
   });
 });
 
-EM_JS(void, emscripten_fenster_loop, (struct fenster *f), {
-  // set alpha to 100%
-  const pmax = f + 8 + Module.canvas.width * Module.canvas.height * 4;
-  for (let p=f+8;p < pmax;p+=4) {
-    Module.HEAPU8[p+3] = 0xFF;
+EM_JS(void, emscripten_fenster_loop, (int width, int height, uint32_t* buf), {
+  const byteSize = width * height * 4;
+  const buffer = Module.HEAPU8.subarray(buf, buf + byteSize);
+  // set alpha to 100% and re-arrange RGBA
+  let r,g,b = 0;
+  for (let i=0;i<byteSize;i+=4) {
+    r = buffer[i+2];
+    g = buffer[i+1];
+    b = buffer[i+0];
+    buffer[i+0] = r;
+    buffer[i+1] = g;
+    buffer[i+2] = b;
+    buffer[i+3] = 0xff;
   }
-  const bufSize = Module.canvas.width*Module.canvas.height*4;
-  Module.screen.data.set(Module.HEAPU8.slice(f+8, f+8+bufSize));
+  Module.screen.data.set(buffer);
   Module.ctx.putImageData(Module.screen, 0, 0);
 });
 
 int fenster_loop(struct fenster *f) {
   if (running) {
-    emscripten_fenster_loop(f);
+    emscripten_fenster_loop(f->width, f->height, f->buf);
   }
 
   // this is hack to make it not pin the main-loop (~60fps)
+  // better would be if we can wrap the loop with emscripten_set_main_loop
+  // which also does not require ASYNCIFY
   emscripten_sleep(16);
 
   return running ? 0 : 1;
@@ -84,10 +96,6 @@ int fenster_loop(struct fenster *f) {
 
 void fenster_close(struct fenster *f) {
   running = false;
-}
-
-void fenster_sleep(int64_t ms) {
-  emscripten_sleep(ms);
 }
 
 EM_JS(int64_t, fenster_time, (void), {


### PR DESCRIPTION
This is related to #36 but uses plain emscripten (no need for SDL-shim.)

There are a couple of caveats.

- Because of how the main-loop and sleep works in fenster, you need `ASYNCIFY`, which adds a lot to js. This could be avoided, but would require changes to how fenster works (have a wrapper for a function like `fenster_set_loop(cb)` and don't use `fenster_loop` or `fenster_sleep`.) Asyncify also adds performance overhead, so getting rid of that might really be worth exploring.
- I keep it in a seperate header, because I like the idea of conditionally including it (with `#if EMSCRIPTEN`) so people can choose if they want emscritpen support easily, sort of like audio.

I updated these examples, including `Makefile`:

- drawing-c
- input-c
- minimal-c

For each, they will build for native with `make`, or for web with `emmake make`

some things that could be improved later:
- no sound, but it could be added
- I don't like adding event-listeners without a way to remove them. it's in js-space, so I think they need to be inserted into `Module` so they can be removed in `fenster_close`
- keys need to be very closely checked. All my keyboard-keys worked on linux/chrome and mac/chrome, but I  don't think there is any guarantee these keycodes will match, across browsers or platforms
- fenster-doom would be a nice "kitchen sink" demo for web
- didn't really attempt to port any other languages (go, lua, etc) to emscripten-method. They have their own ways of binding to web-wasm, and it can get complicated.
