### PR TITLE
change CLOCK_REALTIME to CLOCK_MONOTONIC because it is more robust

### DIFF
--- a/fenster.h
+++ b/fenster.h
@@ -327,7 +327,7 @@ FENSTER_API void fenster_sleep(int64_t ms) {
 }
 FENSTER_API int64_t fenster_time(void) {
   struct timespec time;
-  clock_gettime(CLOCK_REALTIME, &time);
+  clock_gettime(CLOCK_MONOTONIC, &time);
   return time.tv_sec * 1000 + (time.tv_nsec / 1000000);
 }
 #endif


### PR DESCRIPTION
The `fenster_time` function should use `CLOCK_MONOTONIC` instead of `CLOCK_REALTIME` as the argument to `clock_gettime`, since this is "not affected by discontinuous in the system time (e.g., if  the  system  manually  changes the clock)[...] All CLOCK_MONOTONIC variants guarantee that the time  returned  by consecutive  calls will not go backwards". (man page)

This is in contrast to the currently used `CLOCK_REALTIME`, which is affected by such jumps.
