### PR TITLE
Fixed deprecation warning on OSX

### DIFF
--- a/fenster.h
+++ b/fenster.h
@@ -78,7 +78,7 @@ static void fenster_draw_rect(id v, SEL s, CGRect r) {
       NULL, f->buf, f->width * f->height * 4, NULL);
   CGImageRef img =
       CGImageCreate(f->width, f->height, 8, 32, f->width * 4, space,
-                    kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Little,
+                    (CGBitmapInfo)kCGImageAlphaNoneSkipFirst | (CGBitmapInfo)kCGBitmapByteOrder32Little,
                     provider, NULL, false, kCGRenderingIntentDefault);
   CGColorSpaceRelease(space);
   CGDataProviderRelease(provider);


### PR DESCRIPTION
Changed `kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Little` 
to `(CGBitmapInfo)kCGImageAlphaNoneSkipFirst | (CGBitmapInfo)kCGBitmapByteOrder32Little` in
order to fix **-Wdeprecated-anon-enum-enum-conversion** on OSX

The warning when compiling was:
    _bitwise operation between different enumeration types ('CGImageAlphaInfo' and 'unnamed enum') is deprecated_

Apples Headers changed and now recommend to cast both of them into a CGBitmapInfo

This change does not affect runtime behavior, it only resolves the deprecation warning and follows Apple's recommended usage.